### PR TITLE
use start-stop-daemon instead of nohup to daemonize to prevent nohup.out disk fill

### DIFF
--- a/manifests/kafka_rest/service.pp
+++ b/manifests/kafka_rest/service.pp
@@ -4,6 +4,7 @@ class confluent::kafka_rest::service (
   $daemonname = 'kafka-rest',
   $propertyname = 'kafka-rest.properties',
   $pidpattern = '[k]afka-rest',
+  $pidfile = '/var/run/kafka-rest.pid',
   $require_zookeeper = false,
   $require_kafka = false,
   $require_schema_registry = false,

--- a/manifests/kafka_server/service.pp
+++ b/manifests/kafka_server/service.pp
@@ -4,6 +4,7 @@ class confluent::kafka_server::service (
   $daemonname        = 'kafka-server',
   $propertyname      = 'server.properties',
   $pidpattern        = '[k]afkaServer',
+  $pidfile           = '/var/run/kafka-server.pid',
   $kafka_opts        = $confluent::kafka_server_opts,
   $heap_opts         = $confluent::kafka_server_heap_opts,
   $require_zookeeper = true,
@@ -11,7 +12,7 @@ class confluent::kafka_server::service (
 
   file { '/etc/init.d/kafka-server':
     ensure  => file,
-    mode    => '0755',    
+    mode    => '0755',
     content => template('confluent/init.erb'),
     require => Package[ "confluent-kafka-${::confluent::scala_version}" ],
   }

--- a/manifests/schema_registry/service.pp
+++ b/manifests/schema_registry/service.pp
@@ -3,10 +3,11 @@ class confluent::schema_registry::service (
   $configpath = '/etc/schema-registry',
   $daemonname = 'schema-registry',
   $propertyname = 'schema-registry.properties',
+  $pidfile = '/var/run/schema-registry.pid',
   $pidpattern = '[s]chema-registry',
   $require_zookeeper = true,
   $require_kafka = true,
- ) {
+) {
 
   file { '/etc/init.d/kafka-schema_registry':
     ensure  => file,

--- a/manifests/zookeeper/service.pp
+++ b/manifests/zookeeper/service.pp
@@ -4,9 +4,10 @@ class confluent::zookeeper::service (
   $daemonname   = 'zookeeper-server',
   $propertyname = 'zookeeper.properties',
   $pidpattern   = '[z]ookeeper.server',
+  $pidfile      = '/var/run/zookeeper.pid',
   $kafka_opts   = $confluent::zookeeper_opts,
   $heap_opts    = $confluent::zookeeper_heap_opts,
-) { 
+) {
 
   file { '/etc/init.d/zookeeper':
     ensure  => file,

--- a/templates/init.erb
+++ b/templates/init.erb
@@ -14,6 +14,7 @@ DAEMON_PATH="<%= @daemonpath %>"
 CONFIG_PATH="<%= @configpath %>"
 DAEMON_NAME="<%= @daemonname %>"
 PROPERTY_NAME="<%= @propertyname %>"
+PIDFILE="<%= @pidfile %>"
 PID_PATTERN="<%= @pidpattern %>"
 export KAFKA_HEAP_OPTS="<%= @heap_opts %>"
 export KAFKA_OPTS="<%= @kafka_opts %>"
@@ -25,13 +26,13 @@ case "$1" in
   start)
     # Start daemon.
     echo "Starting $DAEMON_NAME";
-    $DAEMON_PATH/$DAEMON_NAME-start -daemon $CONFIG_PATH/$PROPERTY_NAME
+    start-stop-daemon --background --start --pidfile $PIDFILE --make-pidfile --startas $DAEMON_PATH/$DAEMON_NAME-start $CONFIG_PATH/$PROPERTY_NAME
     exit $?
     ;;
   stop)
     # Stop daemons.
     echo "Shutting down $DAEMON_NAME";
-    $DAEMON_PATH/$DAEMON_NAME-stop
+    start-stop-daemon --stop --pidfile $PIDFILE --remove-pidfile --retry 5
     exit $?
   ;;
   restart)

--- a/templates/init.erb
+++ b/templates/init.erb
@@ -32,7 +32,7 @@ case "$1" in
   stop)
     # Stop daemons.
     echo "Shutting down $DAEMON_NAME";
-    start-stop-daemon --stop --pidfile $PIDFILE --remove-pidfile --retry 5
+    start-stop-daemon --stop --pidfile $PIDFILE --retry 5
     exit $?
   ;;
   restart)


### PR DESCRIPTION
The core confluent packages use nohup if the -daemon flag is passed:

https://github.com/confluentinc/schema-registry/blob/master/bin/schema-registry-run-class#L139

Let's use start-stop-daemon --background instead in the init script and avoid passing the -daemon flag so the downstream scrip uses exec instead of nohup.